### PR TITLE
Change submodule path from SSH to HTTPS.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "basic/fpgasoc"]
 	path = basic/fpgasoc
-	url = git@github.com:esden/hadbadge2019_fpgasoc.git
+	url = https://github.com/esden/hadbadge2019_fpgasoc.git


### PR DESCRIPTION
This bypasses the need for everyone cloning this to have valid SSH keys on github.